### PR TITLE
conan: Remove header only

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -17,6 +17,3 @@ class RapidjsonConan(ConanFile):
 
         # headers
         self.copy("*.h*", src=base + "include", dst=relative + "include")
-
-    def package_id(self):
-        self.info.header_only()


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/694

Using header only actually invalidates all settings. These settings are
useful for executable permissions and line endings.